### PR TITLE
Remove PostgreSQL from Docker architecture for production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,23 +3,23 @@ services:
 
   django:
     volumes:
-       - .:/code
+      - .:/code
     environment:
-       - SECRET_KEY=my_dear_secret
-       - DEBUG=True
+      - SECRET_KEY=my_dear_secret
+      - DEBUG=True
     ports:
       - "8000:8000"
 
   tasks:
     volumes:
-       - .:/code
+      - .:/code
     environment:
-       - SECRET_KEY=my_dear_secret
-       - DEBUG=True
+      - SECRET_KEY=my_dear_secret
+      - DEBUG=True
 
   elm:
     volumes:
-       - ./jarbas:/code/jarbas
+      - ./jarbas:/code/jarbas
 
   postgres:
     ports:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - .:/code
     environment:
+      - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
       - SECRET_KEY=my_dear_secret
       - DEBUG=True
     ports:
@@ -14,6 +15,7 @@ services:
     volumes:
       - .:/code
     environment:
+      - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
       - SECRET_KEY=my_dear_secret
       - DEBUG=True
 
@@ -22,5 +24,12 @@ services:
       - ./jarbas:/code/jarbas
 
   postgres:
+    image: postgres:9.6.5-alpine
+    environment:
+      - POSTGRES_PASSWORD=mysecretpassword
+      - POSTGRES_USER=jarbas
+      - POSTGRES_DB=jarbas
+    volumes:
+      - ./db:/var/lib/postgresql
     ports:
       - "5432:5432"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,7 @@ services:
       - "8000"
     volumes:
       - assets:/code/staticfiles
-    command: ["gunicorn", "jarbas.wsgi:application", "--reload", "--bind", "0.0.0.0:8000", "--workers", "4"]
+    command: ["gunicorn", "jarbas.wsgi:application", "--reload", "--bind", "0.0.0.0:8000", "--workers", "2"]
 
   tasks:
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
     networks:
       - backend
     environment:
-       - DEBUG=False
+      - DEBUG=False
 
   queue:
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,13 +65,6 @@ services:
     volumes:
       - assets:/code/jarbas/layers/static
 
-  postgres:
-    expose:
-      - "5432"
-    networks:
-      - backend
-    command: ['-c', 'random_page_cost=1']
-
   memcached:
     image: memcached:1.5.1-alpine
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,28 +5,28 @@ services:
     image: datasciencebr/jarbas-backend
     environment:
        - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
-       - ALLOWED_HOSTS=localhost,127.0.0.1
-       - AMAZON_S3_BUCKET=serenata-de-amor-data
-       - AMAZON_S3_REGION=s3-sa-east-1
-       - AMAZON_S3_CEAPTRANSLATION_DATE=2016-08-08
-       - CELERY_BROKER_URL=amqp://guest:guest@queue/
+      - ALLOWED_HOSTS=localhost,127.0.0.1
+      - AMAZON_S3_BUCKET=serenata-de-amor-data
+      - AMAZON_S3_REGION=s3-sa-east-1
+      - AMAZON_S3_CEAPTRANSLATION_DATE=2016-08-08
+      - CELERY_BROKER_URL=amqp://guest:guest@queue/
     depends_on:
-       - elm
-       - tasks
        - postgres
+      - elm
+      - tasks
     volumes:
-       - "./contrib/data:/mnt/data"
+      - "./contrib/data:/mnt/data"
 
   tasks:
     image: datasciencebr/jarbas-backend
     environment:
        - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
-       - CELERY_BROKER_URL=amqp://guest:guest@queue/
+      - CELERY_BROKER_URL=amqp://guest:guest@queue/
     depends_on:
        - postgres
-       - queue
-    entrypoint: ['/bin/sh', '-c']
-    command: ['celery worker --app jarbas']
+      - queue
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["celery worker --app jarbas"]
 
   elm:
     image: datasciencebr/jarbas-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - queue
     entrypoint: ["/bin/sh", "-c"]
-    command: ["celery worker --app jarbas"]
+    command: ["celery", "worker", "--app", "jarbas"]
 
   elm:
     image: datasciencebr/jarbas-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,12 @@ services:
   django:
     image: datasciencebr/jarbas-backend
     environment:
-       - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
       - ALLOWED_HOSTS=localhost,127.0.0.1
       - AMAZON_S3_BUCKET=serenata-de-amor-data
       - AMAZON_S3_REGION=s3-sa-east-1
       - AMAZON_S3_CEAPTRANSLATION_DATE=2016-08-08
       - CELERY_BROKER_URL=amqp://guest:guest@queue/
     depends_on:
-       - postgres
       - elm
       - tasks
     volumes:
@@ -20,10 +18,8 @@ services:
   tasks:
     image: datasciencebr/jarbas-backend
     environment:
-       - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
       - CELERY_BROKER_URL=amqp://guest:guest@queue/
     depends_on:
-       - postgres
       - queue
     entrypoint: ["/bin/sh", "-c"]
     command: ["celery worker --app jarbas"]
@@ -31,14 +27,6 @@ services:
   elm:
     image: datasciencebr/jarbas-frontend
 
-  postgres:
-    image: postgres:9.6.5-alpine
-    environment:
-      - POSTGRES_PASSWORD=mysecretpassword
-      - POSTGRES_USER=jarbas
-      - POSTGRES_DB=jarbas
-    volumes:
-      - ./db:/var/lib/postgresql
 
   queue:
     image: rabbitmq:3.6.11-alpine


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Running PostgreSQL in our Digital Ocean droplets was too consuming, we needed to fix that.

**What was done to achieve this purpose?**

We moved the database to a dedicated service for now.

**How to test if it really works?**

Access [jarbas.serenata.ai](https://jarbas.serenata.ai) as it is already using this new setup (it was deployed with this branch not `master` after last week crash).

**Who can help reviewing it?**

@Irio @anaschwendler @jtemporal (who loves Docker when it works, which seams to be the case)